### PR TITLE
Nova rank bugged

### DIFF
--- a/Nova rank bugged
+++ b/Nova rank bugged
@@ -1,0 +1,3 @@
+Store says 2 additional sethomes so 1+2=3 but you get only 2 sethomes ing.
+Dosent give you the 25k (i made ticket about that alrdy but put 30k accidentally)
+/redeem gui) does not work ing or is wrong command at the store


### PR DESCRIPTION
Store says 2 additional sethomes so 1+2=3 but you get only 2 sethomes ing.
Dosent give you the 25k (i made ticket about that alrdy but put 30k accidentally)
/redeem gui) does not work ing or is wrong command at the store